### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,6 +19,8 @@ jobs:
   pr-ci:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     services:
       mongo:


### PR DESCRIPTION
Potential fix for [https://github.com/agslima/csv-schema-evolution/security/code-scanning/3](https://github.com/agslima/csv-schema-evolution/security/code-scanning/3)

To resolve the issue, add an explicit `permissions` block to the `pr-ci` job in the `.github/workflows/ci-cd.yml` workflow file. The minimal permissions recommended are `contents: read` (which suffices for all steps in this job, including running lints, tests, and uploading coverage). This change should be made under the `pr-ci:` job definition, by inserting the `permissions:` block after the `runs-on` or `if`/`runs-on` entries, before `services` or other job-level keys. This ensures the GITHUB_TOKEN used by the job has only the required read access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
