### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/01-pr-validation.yml
+++ b/.github/workflows/01-pr-validation.yml
@@ -94,6 +94,8 @@ jobs:
     name: Docker Linting
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@b4ffde65f4633668828d0b93fc293753a9eb8d83 # v4.1.1
 


### PR DESCRIPTION
Potential fix for [https://github.com/agslima/csv-schema-evolution/security/code-scanning/4](https://github.com/agslima/csv-schema-evolution/security/code-scanning/4)

To fix the problem, explicitly restrict the GitHub Actions token permissions for the `docker-lint` job so it does not inherit overly broad repository defaults. Since the job only needs to read the repository contents to run Hadolint, `contents: read` is sufficient.

The best targeted change, without affecting existing behavior, is to add a `permissions:` block under the `docker-lint` job definition (around line 94) with `contents: read`. This keeps the more specific `permissions` already set for `code-quality` unchanged and avoids altering any other workflows. Concretely, in `.github/workflows/01-pr-validation.yml`, under:

```yaml
93:   docker-lint:
94:     name: Docker Linting
95:     runs-on: ubuntu-latest
96:     timeout-minutes: 5
97:     steps:
```

insert:

```yaml
95:     runs-on: ubuntu-latest
96:     timeout-minutes: 5
97:     permissions:
98:       contents: read
99:     steps:
```

No additional methods, imports, or definitions are required because this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
