### PR TITLE
fix: Information exposure through an exception

### DIFF
--- a/backend/app/api/v1/endpoints/health.py
+++ b/backend/app/api/v1/endpoints/health.py
@@ -2,11 +2,14 @@
 Health check API endpoints.
 """
 
+import logging
+
 from fastapi import APIRouter, Response, status
 
 from app.db.mongo import db_manager
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.get("/")
@@ -48,7 +51,8 @@ async def readiness_check(response: Response):
             dependencies["mongo"] = {"status": "ok"}
         # pylint: disable=broad-except
         except Exception as exc:
-            dependencies["mongo"] = {"status": "error", "detail": str(exc)}
+            logger.exception("Mongo readiness check failed", exc_info=exc)
+            dependencies["mongo"] = {"status": "error", "detail": "dependency check failed"}
             ready = False
 
     if db_manager.fs_bucket is None:
@@ -64,7 +68,8 @@ async def readiness_check(response: Response):
             dependencies["gridfs"] = {"status": "ok", "bucket": bucket_name}
         # pylint: disable=broad-except
         except Exception as exc:
-            dependencies["gridfs"] = {"status": "error", "detail": str(exc)}
+            logger.exception("GridFS readiness check failed", exc_info=exc)
+            dependencies["gridfs"] = {"status": "error", "detail": "dependency check failed"}
             ready = False
 
     if not ready:

--- a/backend/tests/unit/test_health_endpoints.py
+++ b/backend/tests/unit/test_health_endpoints.py
@@ -49,7 +49,7 @@ async def test_readiness_check_mongo_ping_failure_marks_gridfs_unavailable(
 
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert payload["dependencies"]["mongo"]["status"] == "error"
-    assert "ping failed" in payload["dependencies"]["mongo"]["detail"]
+    assert payload["dependencies"]["mongo"]["detail"] == "dependency check failed"
     assert payload["dependencies"]["gridfs"]["detail"] == "mongo unavailable"
 
 
@@ -74,7 +74,7 @@ async def test_readiness_check_gridfs_query_failure(monkeypatch):
     assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
     assert payload["dependencies"]["mongo"]["status"] == "ok"
     assert payload["dependencies"]["gridfs"]["status"] == "error"
-    assert "gridfs down" in payload["dependencies"]["gridfs"]["detail"]
+    assert payload["dependencies"]["gridfs"]["detail"] == "dependency check failed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Potential fix for [https://github.com/agslima/csv-schema-evolution/security/code-scanning/7](https://github.com/agslima/csv-schema-evolution/security/code-scanning/7)

Use generic, non-sensitive error details in API responses, and log full exception details server-side.

Best fix in this file:
1. Add a module logger (`import logging` + `logger = logging.getLogger(__name__)`).
2. In both `except Exception as exc` blocks (Mongo ping and GridFS probe), replace `detail: str(exc)` with a generic message (for example, `"dependency check failed"`).
3. Log the exception with stack trace using `logger.exception(...)` so operators keep diagnostics without exposing internals to clients.

Edits are confined to `backend/app/api/v1/endpoints/health.py` in:
- import/header region
- the two `except` blocks in `readiness_check`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
